### PR TITLE
remove basemap from styles

### DIFF
--- a/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/fee-manager.json
+++ b/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/fee-manager.json
@@ -1,109 +1,101 @@
 {
-    "version": 8,
-    "name": "PADUS Fee Managers",
-    "metadata": {},
-    "sources": {
-      "raster-tiles": {
-        "type": "raster",
-        "tiles": [
-          "https://atlas-stg.geoplatform.gov/styles/v1/atlas-user/ck58pyquo009v01p99xebegr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYXRsYXMtdXNlciIsImEiOiJjazFmdGx2bjQwMDAwMG5wZmYwbmJwbmE2In0.lWXK2UexpXuyVitesLdwUg"
-        ],
-        "minzoom": 0,
-        "maxzoom": 14
-      },
-      "padus": {
-        "type": "vector",
-        "tiles": [
-          "https://sit-tileservice.geoplatform.info/vector/a7562280_01d9_55bd_aa44_c7cc88f3b137/{z}/{x}/{y}.mvt"
-        ],
-        "minZoom": 0,
-        "maxZoom": 14
+  "version": 8,
+  "name": "PADUS Fee Managers",
+  "metadata": {},
+  "sources": {
+    "padus": {
+      "type": "vector",
+      "tiles": [
+        "https://sit-tileservice.geoplatform.info/vector/a7562280_01d9_55bd_aa44_c7cc88f3b137/{z}/{x}/{y}.mvt"
+      ],
+      "minZoom": 0,
+      "maxZoom": 14
+    }
+  },
+  "sprite": "https://sit-tileservice.geoplatform.info/assets/sprites/geoplatform",
+  "glyphs": "https://sit-tileservice.geoplatform.info/assets/fonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "fee-fill",
+      "type": "fill",
+      "source": "padus",
+      "source-layer": "fee",
+      "paint": {
+        "fill-color": [
+          "match",
+          [
+            "string",
+            [
+              "get",
+              "Mang_Name"
+            ]
+          ],
+          "DOD",
+          "rgba(128,62,57,255)",
+          "TRIB",
+          "rgba(212,201,181,255)",
+          "BLM",
+          "rgba(242,220,145,255)",
+          "NPS",
+          "rgba(112,161,112,255)",
+          "USFS",
+          "rgba(137,189,42,255)",
+          "USACE",
+          "rgba(99,221,255,255)",
+          "USBR",
+          "rgba(0,92,230,255)",
+          "FWS",
+          "rgba(173,87,100,255)",
+          "NRCS",
+          "rgba(255,66,8,255)",
+          "BPA",
+          "rgba(134,198,108,255)",
+          "ARS",
+          "rgba(134,198,108,255)",
+          "DOE",
+          "rgba(134,198,108,255)",
+          "OTHF",
+          "rgba(134,198,108,255)",
+          "TVA",
+          "rgba(134,198,108,255)",
+          "NGO",
+          "rgba(230,71,71,255)",
+          "SDOL",
+          "rgba(191,124,153,255)",
+          "SDNR",
+          "rgba(191,124,153,255)",
+          "SLB",
+          "rgba(191,124,153,255)",
+          "OTHS",
+          "rgba(171,153,191,255)",
+          "SDC",
+          "rgba(171,153,191,255)",
+          "SFW",
+          "rgba(163,146,222,255)",
+          "SPR",
+          "rgba(155,170,222,255)",
+          "CNTY",
+          "rgba(184,217,87,255)",
+          "REG",
+          "rgba(184,217,87,255)",
+          "RWD",
+          "rgba(184,217,87,255)",
+          "CITY",
+          "rgba(187,196,88,255)",
+          "PVT",
+          "rgba(230,141,69,255)",
+          "JNT",
+          "rgba(227,176,175,255)",
+          "OTHR",
+          "rgba(227,176,175,255)",
+          "UNKL",
+          "rgba(227,176,175,255)",
+          "UNK",
+          "rgba(227,176,175,255)",
+          "rgb(227, 176, 175)"
+        ]
       }
-    },
-    "sprite": "https://sit-tileservice.geoplatform.info/assets/sprites/geoplatform",
-    "glyphs": "https://sit-tileservice.geoplatform.info/assets/fonts/{fontstack}/{range}.pbf",
-    "layers": [
-      {
-        "id": "atlas-tiles",
-        "type": "raster",
-        "source": "raster-tiles",
-        "layout": {"visibility": "visible"}
-      },
-      {
-        "id": "fee-fill",
-        "type": "fill",
-        "source": "padus",
-        "source-layer": "fee",
-        "paint": {
-          "fill-color": [
-            "match",
-            ["string", ["get", "Mang_Name"]],
-            "DOD",
-            "rgba(128,62,57,255)",
-            "TRIB",
-            "rgba(212,201,181,255)",
-            "BLM",
-            "rgba(242,220,145,255)",
-            "NPS",
-            "rgba(112,161,112,255)",
-            "USFS",
-            "rgba(137,189,42,255)",
-            "USACE",
-            "rgba(99,221,255,255)",
-            "USBR",
-            "rgba(0,92,230,255)",
-            "FWS",
-            "rgba(173,87,100,255)",
-            "NRCS",
-            "rgba(255,66,8,255)",
-            "BPA",
-            "rgba(134,198,108,255)",
-            "ARS",
-            "rgba(134,198,108,255)",
-            "DOE",
-            "rgba(134,198,108,255)",
-            "OTHF",
-            "rgba(134,198,108,255)",
-            "TVA",
-            "rgba(134,198,108,255)",
-            "NGO",
-            "rgba(230,71,71,255)",
-            "SDOL",
-            "rgba(191,124,153,255)",
-            "SDNR",
-            "rgba(191,124,153,255)",
-            "SLB",
-            "rgba(191,124,153,255)",
-            "OTHS",
-            "rgba(171,153,191,255)",
-            "SDC",
-            "rgba(171,153,191,255)",
-            "SFW",
-            "rgba(163,146,222,255)",
-            "SPR",
-            "rgba(155,170,222,255)",
-            "CNTY",
-            "rgba(184,217,87,255)",
-            "REG",
-            "rgba(184,217,87,255)",
-            "RWD",
-            "rgba(184,217,87,255)",
-            "CITY",
-            "rgba(187,196,88,255)",
-            "PVT",
-            "rgba(230,141,69,255)",
-            "JNT",
-            "rgba(227,176,175,255)",
-            "OTHR",
-            "rgba(227,176,175,255)",
-            "UNKL",
-            "rgba(227,176,175,255)",
-            "UNK",
-            "rgba(227,176,175,255)",
-            "rgb(227, 176, 175)"
-          ]
-        }
-      }
-    ],
-    "id": "fee-managers"
-  }
+    }
+  ],
+  "id": "fee-managers"
+}

--- a/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/manager-name.json
+++ b/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/manager-name.json
@@ -3,14 +3,6 @@
   "name": "PADUS Manager Name",
   "metadata": {},
   "sources": {
-    "raster-tiles": {
-      "type": "raster",
-      "tiles": [
-        "https://atlas-stg.geoplatform.gov/styles/v1/atlas-user/ck58pyquo009v01p99xebegr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYXRsYXMtdXNlciIsImEiOiJjazFmdGx2bjQwMDAwMG5wZmYwbmJwbmE2In0.lWXK2UexpXuyVitesLdwUg"
-      ],
-      "minzoom": 0,
-      "maxzoom": 14
-    },
     "padus": {
       "type": "vector",
       "tiles": [
@@ -23,14 +15,6 @@
   "sprite": "https://sit-tileservice.geoplatform.info/assets/sprites/geoplatform",
   "glyphs": "https://sit-tileservice.geoplatform.info/assets/fonts/{fontstack}/{range}.pbf",
   "layers": [
-    {
-      "id": "atlas-tiles",
-      "type": "raster",
-      "source": "raster-tiles",
-      "layout": {
-        "visibility": "visible"
-      }
-    },
     {
       "id": "fee-fill",
       "type": "fill",

--- a/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/manager-type.json
+++ b/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/manager-type.json
@@ -3,14 +3,6 @@
     "name": "PADUS Manager Type",
     "metadata": {},
     "sources": {
-        "raster-tiles": {
-            "type": "raster",
-            "tiles": [
-                "https://atlas-stg.geoplatform.gov/styles/v1/atlas-user/ck58pyquo009v01p99xebegr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYXRsYXMtdXNlciIsImEiOiJjazFmdGx2bjQwMDAwMG5wZmYwbmJwbmE2In0.lWXK2UexpXuyVitesLdwUg"
-            ],
-            "minzoom": 0,
-            "maxzoom": 14
-        },
         "padus": {
             "type": "vector",
             "tiles": [
@@ -23,14 +15,6 @@
     "sprite": "https://sit-tileservice.geoplatform.info/assets/sprites/geoplatform",
     "glyphs": "https://sit-tileservice.geoplatform.info/assets/fonts/{fontstack}/{range}.pbf",
     "layers": [
-        {
-            "id": "atlas-tiles",
-            "type": "raster",
-            "source": "raster-tiles",
-            "layout": {
-                "visibility": "visible"
-            }
-        },
         {
             "id": "fee-fill",
             "type": "fill",

--- a/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/protection-mechanism-category.json
+++ b/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/protection-mechanism-category.json
@@ -3,60 +3,56 @@
   "name": "PADUS Protection Mechanism Category",
   "metadata": {},
   "sources": {
-      "raster-tiles": {
-          "type": "raster",
-          "tiles": [
-              "https://atlas-stg.geoplatform.gov/styles/v1/atlas-user/ck58pyquo009v01p99xebegr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYXRsYXMtdXNlciIsImEiOiJjazFmdGx2bjQwMDAwMG5wZmYwbmJwbmE2In0.lWXK2UexpXuyVitesLdwUg"
-          ],
-          "minzoom": 0,
-          "maxzoom": 14
-      },
-      "padus": {
-          "type": "vector",
-          "tiles": [
-              "https://sit-tileservice.geoplatform.info/vector/a7562280_01d9_55bd_aa44_c7cc88f3b137/{z}/{x}/{y}.mvt"
-          ],
-          "minZoom": 0,
-          "maxZoom": 14
-      }
+    "padus": {
+      "type": "vector",
+      "tiles": [
+        "https://sit-tileservice.geoplatform.info/vector/a7562280_01d9_55bd_aa44_c7cc88f3b137/{z}/{x}/{y}.mvt"
+      ],
+      "minZoom": 0,
+      "maxZoom": 14
+    }
   },
   "sprite": "https://sit-tileservice.geoplatform.info/assets/sprites/geoplatform",
   "glyphs": "https://sit-tileservice.geoplatform.info/assets/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
-      "id": "atlas-tiles",
-      "type": "raster",
-      "source": "raster-tiles",
-      "layout": {"visibility": "visible"}
-    },
-    {
       "id": "fee-fill",
       "type": "fill",
       "source": "padus",
       "source-layer": "fee",
-      "layout": {"visibility": "visible"},
-      "paint": {"fill-color": "rgb(56, 168, 0)"}
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "rgb(56, 168, 0)"
+      }
     },
     {
       "id": "designation",
       "type": "fill",
       "source": "padus",
       "source-layer": "designation",
-      "paint": {"fill-color": "rgb(128, 197, 53)"}
+      "paint": {
+        "fill-color": "rgb(128, 197, 53)"
+      }
     },
     {
       "id": "easement",
       "type": "fill",
       "source": "padus",
       "source-layer": "easement",
-      "paint": {"fill-color": "rgb(255, 153, 0)"}
+      "paint": {
+        "fill-color": "rgb(255, 153, 0)"
+      }
     },
     {
       "id": "marine",
       "type": "fill",
       "source": "padus",
       "source-layer": "marine",
-      "paint": {"fill-color": "rgb(0, 153, 153)"}
+      "paint": {
+        "fill-color": "rgb(0, 153, 153)"
+      }
     }
   ],
   "id": "protection-mechanism-category"

--- a/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/protection-status-by-gap-status-code.json
+++ b/mvt/styles/a7562280_01d9_55bd_aa44_c7cc88f3b137/protection-status-by-gap-status-code.json
@@ -3,14 +3,6 @@
   "name": "PADUS Protection Status by GAP Status Code",
   "metadata": {},
   "sources": {
-    "raster-tiles": {
-      "type": "raster",
-      "tiles": [
-        "https://atlas-stg.geoplatform.gov/styles/v1/atlas-user/ck58pyquo009v01p99xebegr9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYXRsYXMtdXNlciIsImEiOiJjazFmdGx2bjQwMDAwMG5wZmYwbmJwbmE2In0.lWXK2UexpXuyVitesLdwUg"
-      ],
-      "minzoom": 0,
-      "maxzoom": 14
-    },
     "padus": {
       "type": "vector",
       "tiles": [
@@ -24,14 +16,6 @@
   "glyphs": "https://sit-tileservice.geoplatform.info/assets/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
-      "id": "atlas-tiles",
-      "type": "raster",
-      "source": "raster-tiles",
-      "layout": {
-        "visibility": "visible"
-      }
-    },
-    {
       "id": "fee-fill",
       "type": "fill",
       "source": "padus",
@@ -39,7 +23,13 @@
       "paint": {
         "fill-color": [
           "match",
-          ["string", ["get", "GAP_Sts"]],
+          [
+            "string",
+            [
+              "get",
+              "GAP_Sts"
+            ]
+          ],
           "1",
           "rgba(38,99,61,255)",
           "2",


### PR DESCRIPTION
This *should* fix the JS error - each style contained the atlas basemap with same id as whats in the tilegarden viewer. I removed the basemap from each style. 